### PR TITLE
Add feature to pre-fill error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+* Pre-fill error context at the begining of a request or job with RorVsWild.merge_error_context(hash)
+
+## 1.5.12
+
+* Fix config API key
+
+## 1.5.11
+
+* Add option to change widget position
+
+## 1.5.10
+
+* Decrease log level to debug
+* Improve relevant path
+
+## 1.5.9
+
+* Remove cwd in paths
+* Add Ruby version HTTP header
+* Add environment context to errors (OS, Ruby version, cwd, host and PID)
+
+## 1.5.8
+
+* Ensure Resque plugin is not installed twice
+
+## 1.5.7
+
+* Fix for Rails 4.2 where ActionController::API does not exist
+
+## 1.5.6
+
+* Add support for ActionController::API
+
+## 1.5.5
+
+* Add Rails version HTTP header
+* Use HTTP persistent connections
+
+## 1.5.4
+
+* Replace process_action.action_controller callback since it cannot get controller instance in Rails 4
+
+## 1.5.3
+
+* Replace action dispatch plugin by a rack middleware
+
+## 1.5.2
+
+* Accept all loggers as long as they respond to info, warn and error
+* Add RorVsWild.check
+* Fix ensure block for old Ruby versions
+* Optimize relevant path Locator
+* Measure ActionDispatch
+
+## 1.5.1
+
+* Use Rails.logger by default
+
+## 1.5.0
+
+* Support Faktory jobs

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ RorVsWild.record_error(exception, {something: "important"})
 RorVsWild.catch_error(something: "important") { 1 / 0 }
 ```
 
+It is also possible to pre-fill this context data at the begining of each request or job :
+
+```ruby
+class ApplicationController < ActionController::Base
+  before_action :prefill_error_context
+
+  def prefill_error_context
+    RorVsWild.merge_error_context(something: "important")
+  end
+end
+```
+
 #### Ignore requests, jobs, exceptions and plugins
 
 From the configuration file, you can tell RorVsWild to skip monitoring some requests, jobs, exceptions and plugins.

--- a/lib/rorvswild.rb
+++ b/lib/rorvswild.rb
@@ -39,6 +39,10 @@ module RorVsWild
     agent.record_error(exception, extra_details) if agent
   end
 
+  def self.merge_error_context(hash)
+    agent.merge_error_context(hash) if agent
+  end
+
   def self.initialize_logger(destination = nil)
     if destination.respond_to?(:info) && destination.respond_to?(:warn) && destination.respond_to?(:error)
       destination

--- a/lib/rorvswild/agent.rb
+++ b/lib/rorvswild/agent.rb
@@ -113,6 +113,18 @@ module RorVsWild
       current_data[:error]
     end
 
+    def merge_error_context(hash)
+      self.error_context = error_context ? error_context.merge(hash) : hash
+    end
+
+    def error_context
+      current_data[:error_context] if current_data
+    end
+
+    def error_context=(hash)
+      current_data[:error_context] = hash if current_data
+    end
+
     def current_data
       Thread.current[:rorvswild_data]
     end
@@ -162,15 +174,16 @@ module RorVsWild
       client.post_async("/errors".freeze, error: hash)
     end
 
-    def exception_to_hash(exception, extra_details = nil)
+    def exception_to_hash(exception, context = nil)
       file, line = locator.find_most_relevant_file_and_line_from_exception(exception)
+      context = context ? error_context.merge(context) : error_context if error_context
       {
         line: line.to_i,
         file: locator.relative_path(file),
         message: exception.message,
         backtrace: exception.backtrace || ["No backtrace"],
         exception: exception.class.to_s,
-        extra_details: extra_details,
+        extra_details: context,
         environment: {
           os: os_description,
           user: Etc.getlogin,

--- a/test/plugin/action_controller_test.rb
+++ b/test/plugin/action_controller_test.rb
@@ -18,6 +18,8 @@ class RorVsWild::Plugin::ActionControllerTest < Minitest::Test
 
   def test_after_exception
     agent.start_request
+    RorVsWild.merge_error_context(user_id: 123)
+    RorVsWild.merge_error_context(other_id: 456)
     controller = SampleController.new
     controller.action_name = "index"
     controller.stubs(request: stub(filtered_parameters: {foo: "bar"}, filtered_env: {"HTTP_CONTENT_TYPE" => "HTML"}, method: "GET", url: "http://localhost:3000/test"))
@@ -32,6 +34,7 @@ class RorVsWild::Plugin::ActionControllerTest < Minitest::Test
     assert_equal("http://localhost:3000/test", data[:error][:request][:url])
     assert_equal("GET", data[:error][:request][:method])
     assert(data[:error][:environment][:os])
+    assert_equal({user_id: 123, other_id: 456}, data[:error][:extra_details])
   end
 
   def test_around_action_for_api_controller


### PR DESCRIPTION
At the beginin of a request or a job RorVsWild.merge_error_context(hash)