### PR TITLE
File#exists? has been deprecated and removed

### DIFF
--- a/lib/rorvswild/installer.rb
+++ b/lib/rorvswild/installer.rb
@@ -4,7 +4,7 @@ module RorVsWild
 
     def self.create_rails_config(api_key)
       if File.directory?("config")
-        if !File.exists?(PATH)
+        if !File.exist?(PATH)
           File.write(PATH, template(api_key))
           puts "File #{PATH} has been created. Restart / deploy your app to start collecting data."
         else


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17391


```
❯ rorvswild-install [my_token_here]
/Users/miharekar/.gem/ruby/3.2.0/gems/rorvswild-1.6.0/lib/rorvswild/installer.rb:7:in `create_rails_config': undefined method `exists?' for File:Class (NoMethodError)

        if !File.exists?(PATH)
                ^^^^^^^^
Did you mean?  exist?
	from /Users/miharekar/.gem/ruby/3.2.0/gems/rorvswild-1.6.0/bin/rorvswild-install:8:in `<top (required)>'
	from /Users/miharekar/.gem/ruby/3.2.0/bin/rorvswild-install:25:in `load'
	from /Users/miharekar/.gem/ruby/3.2.0/bin/rorvswild-install:25:in `<main>'
```