### PR TITLE
Track request queue time based on available request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Unreleased
 
 * Measure render collection
+* Requests now report the time they have been queued by the proxy before reaching the application.
+
+  A section with the kind `queue` reports the time between the timestamp set by the HTTP proxy
+  when the request was received and the time the application started processing the request.
+
+  This time is also included into the total runtime of the request.
 
 ## 1.8.1 (2024-10-17)
 

--- a/lib/rorvswild/agent.rb
+++ b/lib/rorvswild/agent.rb
@@ -114,15 +114,15 @@ module RorVsWild
       end
     end
 
-    def start_request
-      current_data || initialize_data
+    def start_request(queue_time_ms = 0)
+      current_data || initialize_data(queue_time_ms)
     end
 
     def stop_request
       return unless data = current_data
       gc = Section.stop_gc_timing(data[:gc_section])
       data[:sections] << gc if gc.calls > 0 && gc.total_ms > 0
-      data[:runtime] = RorVsWild.clock_milliseconds - (current_data[:queued_at] || current_data[:started_at])
+      data[:runtime] = RorVsWild.clock_milliseconds - current_data[:started_at]
       queue_request
     end
 
@@ -195,9 +195,9 @@ module RorVsWild
 
     private
 
-    def initialize_data
+    def initialize_data(queue_time_ms = 0)
       Thread.current[:rorvswild_data] = {
-        started_at: RorVsWild.clock_milliseconds,
+        started_at: RorVsWild.clock_milliseconds - queue_time_ms,
         gc_section: Section.start_gc_timing,
         environment: Host.to_h,
         section_stack: [],

--- a/lib/rorvswild/agent.rb
+++ b/lib/rorvswild/agent.rb
@@ -122,8 +122,7 @@ module RorVsWild
       return unless data = current_data
       gc = Section.stop_gc_timing(data[:gc_section])
       data[:sections] << gc if gc.calls > 0 && gc.total_ms > 0
-      data[:runtime] = RorVsWild.clock_milliseconds - current_data[:started_at]
-      data[:runtime] += data[:sections].sum(0) { |s| s.kind == "queue" ? s.self_ms : 0 }
+      data[:runtime] = RorVsWild.clock_milliseconds - (current_data[:queued_at] || current_data[:started_at])
       queue_request
     end
 

--- a/lib/rorvswild/agent.rb
+++ b/lib/rorvswild/agent.rb
@@ -123,6 +123,7 @@ module RorVsWild
       gc = Section.stop_gc_timing(data[:gc_section])
       data[:sections] << gc if gc.calls > 0 && gc.total_ms > 0
       data[:runtime] = RorVsWild.clock_milliseconds - current_data[:started_at]
+      data[:runtime] += data[:sections].sum(0) { |s| s.kind == "queue" ? s.self_ms : 0 }
       queue_request
     end
 

--- a/lib/rorvswild/plugin/middleware.rb
+++ b/lib/rorvswild/plugin/middleware.rb
@@ -4,14 +4,11 @@ module RorVsWild
   module Plugin
     class Middleware
       module RequestQueueTime
-        REQUEST_START_HEADER = 'HTTP_X_REQUEST_START'.freeze
-        QUEUE_START_HEADER = 'HTTP_X_QUEUE_START'.freeze
-        MIDDLEWARE_START_HEADER = 'HTTP_X_MIDDLEWARE_START'.freeze
 
         ACCEPTABLE_HEADERS = [
-          REQUEST_START_HEADER,
-          QUEUE_START_HEADER,
-          MIDDLEWARE_START_HEADER
+          'HTTP_X_REQUEST_START',
+          'HTTP_X_QUEUE_START',
+          'HTTP_X_MIDDLEWARE_START'
         ].freeze
 
         MINIMUM_TIMESTAMP = 1577836800.freeze # 2020/01/01 UTC
@@ -24,7 +21,7 @@ module RorVsWild
 
           ACCEPTABLE_HEADERS.each do |header|
             if (header_value = env[header])
-              timestamp = parse_timestamp(header_value.gsub("t=", ""))
+              timestamp = parse_timestamp(header_value.delete_prefix("t="))
               if timestamp && (!earliest || timestamp < earliest)
                 earliest = timestamp
               end

--- a/lib/rorvswild/plugin/middleware.rb
+++ b/lib/rorvswild/plugin/middleware.rb
@@ -82,6 +82,7 @@ module RorVsWild
           section.line = 0
           section.kind = "queue"
           RorVsWild.agent.add_section(section)
+          RorVsWild.agent.current_data[:queued_at] = RorVsWild.agent.current_data[:started_at] - queue_time
         end
       end
 

--- a/test/plugin/middleware_test.rb
+++ b/test/plugin/middleware_test.rb
@@ -24,6 +24,9 @@ class RorVsWild::Plugin::MiddlewareTest < Minitest::Test
 
     middleware.call(request)
 
+    assert_predicate agent.current_data[:queued_at], :present?
+    assert agent.current_data[:queued_at] <= agent.current_data[:started_at]
+
     assert_equal(2, agent.current_data[:sections].size)
     queue_time_section = agent.current_data[:sections][0]
     assert_equal "request-queue", queue_time_section.file

--- a/test/plugin/middleware_test.rb
+++ b/test/plugin/middleware_test.rb
@@ -24,9 +24,6 @@ class RorVsWild::Plugin::MiddlewareTest < Minitest::Test
 
     middleware.call(request)
 
-    assert_predicate agent.current_data[:queued_at], :present?
-    assert agent.current_data[:queued_at] <= agent.current_data[:started_at]
-
     assert_equal(2, agent.current_data[:sections].size)
     queue_time_section = agent.current_data[:sections][0]
     assert_equal "request-queue", queue_time_section.file

--- a/test/plugin/middleware_test.rb
+++ b/test/plugin/middleware_test.rb
@@ -5,7 +5,7 @@ class RorVsWild::Plugin::MiddlewareTest < Minitest::Test
 
   def test_callback
     agent # Load agent
-    request = {"ORIGINAL_FULLPATH" => "/foo/bar"}
+    request = { "ORIGINAL_FULLPATH" => "/foo/bar" }
     app = mock(call: nil)
     middleware = RorVsWild::Plugin::Middleware.new(app, nil)
     middleware.stubs(rails_engine_location: ["/rails/lib/engine.rb", 12])
@@ -13,6 +13,45 @@ class RorVsWild::Plugin::MiddlewareTest < Minitest::Test
     assert_equal("/foo/bar", agent.current_data[:path])
     assert_equal(1, agent.current_data[:sections].size)
     assert_equal("Rails::Engine#call", agent.current_data[:sections][0].command)
+    assert_nil(agent.current_data[:queue_time])
+  end
+
+  def test_queue_time_secs
+    agent # Load agent
+    request_start = unix_timestamp_seconds - 0.123
+    request = {"HTTP_X_REQUEST_START" => request_start.to_s}
+    app = mock(call: nil)
+    middleware = RorVsWild::Plugin::Middleware.new(app, nil)
+    middleware.stubs(rails_engine_location: ["/rails/lib/engine.rb", 12])
+    middleware.call(request)
+    assert_in_delta(123, agent.current_data[:queue_time], 10)
+  end
+
+  def test_queue_time_millis
+    agent # Load agent
+    request_start = unix_timestamp_seconds * 1000 - 234
+    request = { "HTTP_X_QUEUE_START" => request_start.to_s }
+    app = mock(call: nil)
+    middleware = RorVsWild::Plugin::Middleware.new(app, nil)
+    middleware.stubs(rails_engine_location: ["/rails/lib/engine.rb", 12])
+    middleware.call(request)
+    assert_in_delta(234, agent.current_data[:queue_time], 10)
+  end
+
+  def test_queue_time_micros
+    agent # Load agent
+    request_start = unix_timestamp_seconds * 1_000_000 - 345_000
+    request = { "HTTP_X_MIDDLEWARE_START" => request_start.to_s }
+    app = mock(call: nil)
+    middleware = RorVsWild::Plugin::Middleware.new(app, nil)
+    middleware.stubs(rails_engine_location: ["/rails/lib/engine.rb", 12])
+    middleware.call(request)
+    assert_in_delta(345, agent.current_data[:queue_time], 10)
+  end
+
+  private
+
+  def unix_timestamp_seconds
+    Time.now.to_f
   end
 end
-


### PR DESCRIPTION
Hi,

I've been using the gem for a while and I added a way to parse common queue time headers. 

It's been very useful to determine queue time of requests on the proxy level (before reaching the application) as it is a common source for performance issues.

Let me know if you'd be interested in accepting this change at all and I'm happy to refactor if needed.