### PR TITLE
Fix typo in rorvswild.yml

### DIFF
--- a/lib/rorvswild/installer.rb
+++ b/lib/rorvswild/installer.rb
@@ -52,7 +52,7 @@ production:
   # logger: log/rorvswild.log # By default it uses Rails.logger or Logger.new(STDOUT)
   #
   # # Deployment tracking is working without any actions from your part if the Rails app
-  # # is inside a Git repositoriy, is deployed via Capistrano.
+  # # is inside a Git repository, is deployed via Capistrano.
   # # In the other cases, you can provide the following details.
   # deployment:
   #   revision: <%= "Anything that will return the deployment version" %> # Mandatory


### PR DESCRIPTION
It's funny that this actually broke our build on CI, because we scan for typos:

<img width="909" height="341" alt="image" src="https://github.com/user-attachments/assets/411cc34a-6d0c-4585-b900-3aa1f5d92f41" />
